### PR TITLE
Add a retry on 490

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,17 @@
-test: deps
-	go test -v -coverprofile=cover.out .
+# envVars defines all the environment variables the project depends on. These
+# are typically provided by docker-compose files or .env files.
+envVars= \
+	SKYDB_ENTROPY=lJAuxnufpy7BbNCbVUKWShIinDBipdnd1hr/d/ZqHLI= \
+	SKYDB_ENDPOINT=localhost:9980
 
 deps:
 	go get ./...
+
+fmt:
+	gofmt -s -l -w .
+
+vet:
+	go vet .
+
+test: deps fmt vet
+	$(envVars) go test -v -coverprofile=cover.out .

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,8 @@
 # envVars defines all the environment variables the project depends on. These
 # are typically provided by docker-compose files or .env files.
 envVars= \
-	SKYDB_ENTROPY=lJAuxnufpy7BbNCbVUKWShIinDBipdnd1hr/d/ZqHLI= \
-	SKYDB_ENDPOINT=localhost:9980
+	CADDY_SKYDB_ENTROPY=lJAuxnufpy7BbNCbVUKWShIinDBipdnd1hr/d/ZqHLI= \
+	CADDY_SKYDB_ENDPOINT=localhost:9980
 
 deps:
 	go get ./...

--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ resource "aws_dynamodb_table" "CertMagic" {
 ## Contributing
 Please do, we like reported issues and pull requests. 
 
+
 -->
 
 ## License

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ services:
     build: .
     command: make
     environment:
-      SKYDB_ENDPOINT: localhost:9980
-      SKYDB_ENTROPY: ZnXVDQI5SIf3B+bBHM6GJe8nuV9yZm9HSO7liWeo6yk=
+      CADDY_SKYDB_ENDPOINT: localhost:9980
+      CADDY_SKYDB_ENTROPY: ZnXVDQI5SIf3B+bBHM6GJe8nuV9yZm9HSO7liWeo6yk=
     volumes:
       - ./:/certmagic-storage-skydb

--- a/go.mod
+++ b/go.mod
@@ -3,11 +3,10 @@ module github.com/skynetlabs/certmagic-storage-skydb
 go 1.13
 
 require (
-	github.com/aws/aws-sdk-go v1.30.20
 	github.com/caddyserver/caddy/v2 v2.0.0
 	github.com/caddyserver/certmagic v0.11.0
 	gitlab.com/NebulousLabs/errors v0.0.0-20200929122200-06c536cf6975
 	gitlab.com/NebulousLabs/fastrand v0.0.0-20181126182046-603482d69e40 // indirect
-	gitlab.com/SkynetLabs/skyd v1.5.7-0.20210526142136-ba215800db45
-	go.sia.tech/siad v1.5.7-0.20210420210148-0aa0d744a366
+	gitlab.com/SkynetLabs/skyd v1.5.7-0.20210616070938-2cdd82f55574
+	go.sia.tech/siad v1.5.7-0.20210602173250-2beeb3839891
 )

--- a/go.sum
+++ b/go.sum
@@ -768,6 +768,8 @@ gitlab.com/NebulousLabs/writeaheadlog v0.0.0-20200618142844-c59a90f49130 h1:0hiQ
 gitlab.com/NebulousLabs/writeaheadlog v0.0.0-20200618142844-c59a90f49130/go.mod h1:SxigdS5Q1ui+OMgGAXt1E/Fg3RB6PvKXMov2O3gvIzs=
 gitlab.com/SkynetLabs/skyd v1.5.7-0.20210526142136-ba215800db45 h1:D8dSBbht8Kxh0WAdATEN0k3aBww0SLqWXpB4IPzNxSo=
 gitlab.com/SkynetLabs/skyd v1.5.7-0.20210526142136-ba215800db45/go.mod h1:mH2FGZZvx16Ms8GEn3RmLmwOKrR/HvUqxE6Pmh6G/A8=
+gitlab.com/SkynetLabs/skyd v1.5.7-0.20210616070938-2cdd82f55574 h1:TkL/7MO83JnkbHkX+73diNeKl+S2SAUCVP54dfJai0o=
+gitlab.com/SkynetLabs/skyd v1.5.7-0.20210616070938-2cdd82f55574/go.mod h1:iU2cu41mOe1+wL4o2mbYJHId5rs9dC2X8Q2vnud3v6s=
 go.etcd.io/bbolt v1.3.2/go.mod h1:IbVyRI1SCnLcuJnV2u8VeU0CEYM7e686BmAb1XKL+uU=
 go.etcd.io/etcd v3.3.13+incompatible/go.mod h1:yaeTdrJi5lOmYerz05bd8+V7KubZs8YSFZfzsF9A6aI=
 go.etcd.io/etcd v3.3.18+incompatible/go.mod h1:yaeTdrJi5lOmYerz05bd8+V7KubZs8YSFZfzsF9A6aI=
@@ -780,6 +782,8 @@ go.opencensus.io v0.22.2/go.mod h1:yxeiOL68Rb0Xd1ddK5vPZ/oVn4vY4Ynel7k9FzqtOIw=
 go.opencensus.io v0.22.3/go.mod h1:yxeiOL68Rb0Xd1ddK5vPZ/oVn4vY4Ynel7k9FzqtOIw=
 go.sia.tech/siad v1.5.7-0.20210420210148-0aa0d744a366 h1:EMwAYZePE7xzfoRcVMUMiE4AgqlSpbIR4dOMMnYFYFg=
 go.sia.tech/siad v1.5.7-0.20210420210148-0aa0d744a366/go.mod h1:dPsvv+ccxLbU8oCiBABuRlcRnHRy6/K6n671d/9w1LQ=
+go.sia.tech/siad v1.5.7-0.20210602173250-2beeb3839891 h1:DdqtbySLXMkck5ikmsWPri5MQZLN7SC/qnK1XlvRB0U=
+go.sia.tech/siad v1.5.7-0.20210602173250-2beeb3839891/go.mod h1:kyDWr0jcvAAFnxu6o5yxHfDNzXz9g7eT77DbiwaShK4=
 go.uber.org/atomic v1.3.2/go.mod h1:gD2HeocX3+yG+ygLZcrzQJaqmWj9AIm7n08wl/qW/PE=
 go.uber.org/atomic v1.4.0/go.mod h1:gD2HeocX3+yG+ygLZcrzQJaqmWj9AIm7n08wl/qW/PE=
 go.uber.org/atomic v1.5.0/go.mod h1:sABNBOSYdrvTF6hTgEIbc7YasKWGhgEQZyfxyTvoXHQ=
@@ -971,6 +975,8 @@ golang.org/x/sys v0.0.0-20210330210617-4fbd30eecc44 h1:Bli41pIlzTzf3KEY06n+xnzK/
 golang.org/x/sys v0.0.0-20210330210617-4fbd30eecc44/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1 h1:v+OssWQX+hTHEmOBgwxdZxK4zHq3yOs8F9J7mk0PY8E=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
+golang.org/x/term v0.0.0-20210421210424-b80969c67360 h1:3xb4xj+MkwmausKqTNIEMLZsruJPu6p3jrlW8p3eecY=
+golang.org/x/term v0.0.0-20210421210424-b80969c67360/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.0.0-20170915090833-1cbadb444a80/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=

--- a/skydb/skydb.go
+++ b/skydb/skydb.go
@@ -66,7 +66,7 @@ func New() (*SkyDB, error) {
 
 // Read retrieves from SkyDB the data that corresponds to the given key set.
 func (db SkyDB) Read(dataKey crypto.Hash) ([]byte, uint64, error) {
-	fmt.Println(" >>> SkyDB Read ", base64.StdEncoding.EncodeToString(dataKey[:]))
+	//fmt.Println(" >>> SkyDB Read ", base64.StdEncoding.EncodeToString(dataKey[:]))
 	s, rev, err := registryRead(db.Client, db.pk, dataKey)
 	// This error string covers both "not found" and "not found in time".
 	if err != nil && strings.Contains(err.Error(), "registry entry not found") {
@@ -79,13 +79,13 @@ func (db SkyDB) Read(dataKey crypto.Hash) ([]byte, uint64, error) {
 	if err != nil {
 		return nil, 0, errors.AddContext(err, "failed to download data from Skynet")
 	}
-	fmt.Println(" >>> SkyDB Read ", base64.StdEncoding.EncodeToString(dataKey[:]), base64.StdEncoding.EncodeToString(b[:]), rev)
+	///fmt.Println(" >>> SkyDB Read ", base64.StdEncoding.EncodeToString(dataKey[:]), base64.StdEncoding.EncodeToString(b[:]), rev)
 	return b, rev, nil
 }
 
 // Write stores the given `data` in SkyDB under the given key set.
 func (db SkyDB) Write(data []byte, dataKey crypto.Hash, rev uint64) error {
-	fmt.Println(" >>> SkyDB Write ", base64.StdEncoding.EncodeToString(data[:]), base64.StdEncoding.EncodeToString(dataKey[:]), rev)
+	//fmt.Println(" >>> SkyDB Write ", base64.StdEncoding.EncodeToString(data[:]), base64.StdEncoding.EncodeToString(dataKey[:]), rev)
 	skylink, err := uploadData(db.Client, data)
 	if err != nil {
 		return errors.AddContext(err, "failed to upload data")

--- a/skydb/skydb.go
+++ b/skydb/skydb.go
@@ -16,7 +16,13 @@ import (
 	"go.sia.tech/siad/types"
 )
 
-var ErrNotFound = errors.New("skydb entry not found")
+var (
+	ErrNotFound = errors.New("skydb entry not found")
+
+	// BadRevNum is the error message the registry gives when a given registry
+	// number is already used for a given data key
+	BadRevNum = "provided revision number is already registered"
+)
 
 // SkyDBI is the interface for communicating with SkyDB. We use an interface, so
 // we can easily override it for testing purposes.

--- a/skydb/skydb.go
+++ b/skydb/skydb.go
@@ -66,7 +66,6 @@ func New() (*SkyDB, error) {
 
 // Read retrieves from SkyDB the data that corresponds to the given key set.
 func (db SkyDB) Read(dataKey crypto.Hash) ([]byte, uint64, error) {
-	//fmt.Println(" >>> SkyDB Read ", base64.StdEncoding.EncodeToString(dataKey[:]))
 	s, rev, err := registryRead(db.Client, db.pk, dataKey)
 	// This error string covers both "not found" and "not found in time".
 	if err != nil && strings.Contains(err.Error(), "registry entry not found") {
@@ -82,13 +81,11 @@ func (db SkyDB) Read(dataKey crypto.Hash) ([]byte, uint64, error) {
 	if err != nil {
 		return nil, 0, errors.AddContext(err, "failed to download data from Skynet")
 	}
-	///fmt.Println(" >>> SkyDB Read ", base64.StdEncoding.EncodeToString(dataKey[:]), base64.StdEncoding.EncodeToString(b[:]), rev)
 	return b, rev, nil
 }
 
 // Write stores the given `data` in SkyDB under the given key set.
 func (db SkyDB) Write(data []byte, dataKey crypto.Hash, rev uint64) error {
-	//fmt.Println(" >>> SkyDB Write ", base64.StdEncoding.EncodeToString(data[:]), base64.StdEncoding.EncodeToString(dataKey[:]), rev)
 	skylink, err := uploadData(db.Client, data)
 	if err != nil {
 		return errors.AddContext(err, "failed to upload data")

--- a/skydb/skydb.go
+++ b/skydb/skydb.go
@@ -5,6 +5,7 @@ import (
 	"encoding/base64"
 	"fmt"
 	"os"
+	"strings"
 	"time"
 
 	"gitlab.com/NebulousLabs/errors"
@@ -66,14 +67,14 @@ func (db SkyDB) Read(dataKey crypto.Hash) ([]byte, uint64, error) {
 	waitUntilSkydReady(db.Client)
 	s, rev, err := registryRead(db.Client, db.pk, dataKey)
 	// This error string covers both "not found" and "not found in time".
-	if err != nil && (errors.Contains(err, renter.ErrRegistryEntryNotFound) || errors.Contains(err, renter.ErrRegistryLookupTimeout)) {
+	if err != nil && (strings.Contains(err.Error(), renter.ErrRegistryEntryNotFound.Error()) || strings.Contains(err.Error(), renter.ErrRegistryLookupTimeout.Error())) {
 		return nil, 0, ErrNotFound
 	}
 	if err != nil {
 		return nil, 0, errors.AddContext(err, "skydb failed to read from registry")
 	}
 	b, err := db.Client.SkynetSkylinkGet(s.String())
-	if err != nil && errors.Contains(err, renter.ErrRootNotFound) {
+	if err != nil && strings.Contains(err.Error(), renter.ErrRootNotFound.Error()) {
 		return nil, 0, ErrNotFound
 	}
 	if err != nil {

--- a/skydb/skydb.go
+++ b/skydb/skydb.go
@@ -16,7 +16,7 @@ import (
 	"go.sia.tech/siad/types"
 )
 
-var ErrNotFound = errors.New("entry not found")
+var ErrNotFound = errors.New("skydb entry not found")
 
 // SkyDBI is the interface for communicating with SkyDB. We use an interface, so
 // we can easily override it for testing purposes.
@@ -61,11 +61,12 @@ func New() (*SkyDB, error) {
 // Read retrieves from SkyDB the data that corresponds to the given key set.
 func (db SkyDB) Read(dataKey crypto.Hash) ([]byte, uint64, error) {
 	s, rev, err := registryRead(db.Client, db.pk, dataKey)
-	if err != nil && strings.Contains(err.Error(), "registry entry not found within given time") {
+	// This error string covers both "not found" and "not found in time".
+	if err != nil && strings.Contains(err.Error(), "registry entry not found") {
 		return nil, 0, ErrNotFound
 	}
 	if err != nil {
-		return nil, 0, errors.AddContext(err, "failed to read from registry")
+		return nil, 0, errors.AddContext(err, "skydb failed to read from registry")
 	}
 	b, err := db.Client.SkynetSkylinkGet(s.String())
 	if err != nil {

--- a/skydb/skydb.go
+++ b/skydb/skydb.go
@@ -60,6 +60,7 @@ func New() (*SkyDB, error) {
 
 // Read retrieves from SkyDB the data that corresponds to the given key set.
 func (db SkyDB) Read(dataKey crypto.Hash) ([]byte, uint64, error) {
+	fmt.Println(" >>> SkyDB Read ", base64.StdEncoding.EncodeToString(dataKey[:]))
 	s, rev, err := registryRead(db.Client, db.pk, dataKey)
 	// This error string covers both "not found" and "not found in time".
 	if err != nil && strings.Contains(err.Error(), "registry entry not found") {
@@ -72,11 +73,13 @@ func (db SkyDB) Read(dataKey crypto.Hash) ([]byte, uint64, error) {
 	if err != nil {
 		return nil, 0, errors.AddContext(err, "failed to download data from Skynet")
 	}
+	fmt.Println(" >>> SkyDB Read ", base64.StdEncoding.EncodeToString(dataKey[:]), base64.StdEncoding.EncodeToString(b[:]), rev)
 	return b, rev, nil
 }
 
 // Write stores the given `data` in SkyDB under the given key set.
 func (db SkyDB) Write(data []byte, dataKey crypto.Hash, rev uint64) error {
+	fmt.Println(" >>> SkyDB Write ", base64.StdEncoding.EncodeToString(data[:]), base64.StdEncoding.EncodeToString(dataKey[:]), rev)
 	skylink, err := uploadData(db.Client, data)
 	if err != nil {
 		return errors.AddContext(err, "failed to upload data")

--- a/skydb/skydb.go
+++ b/skydb/skydb.go
@@ -67,9 +67,11 @@ func (db SkyDB) Read(dataKey crypto.Hash) ([]byte, uint64, error) {
 	s, rev, err := registryRead(db.Client, db.pk, dataKey)
 	// This error string covers both "not found" and "not found in time".
 	if err != nil && (errors.Contains(err, renter.ErrRegistryEntryNotFound) || errors.Contains(err, renter.ErrRegistryLookupTimeout)) {
+		fmt.Println(" >>> Read: Not Found:", err)
 		return nil, 0, ErrNotFound
 	}
 	if err != nil {
+		fmt.Println(" >>> Read: Error:", err)
 		return nil, 0, errors.AddContext(err, "skydb failed to read from registry")
 	}
 	b, err := db.Client.SkynetSkylinkGet(s.String())
@@ -122,7 +124,7 @@ func registryWrite(c *client.Client, skylink string, sk crypto.SecretKey, pk cry
 	}
 	// Update the registry with that link.
 	spk := types.Ed25519PublicKey(pk)
-	srv := modules.NewRegistryValue(dataKey, sl.Bytes(), rev, modules.RegistryTypeWithPubkey).Sign(sk)
+	srv := modules.NewRegistryValue(dataKey, sl.Bytes(), rev, modules.RegistryTypeWithoutPubkey).Sign(sk)
 	err = c.RegistryUpdate(spk, dataKey, srv.Revision, srv.Signature, sl)
 	if err != nil {
 		return skymodules.Skylink{}, err

--- a/skydb/skydb.go
+++ b/skydb/skydb.go
@@ -44,9 +44,9 @@ func New() (*SkyDB, error) {
 		return nil, err
 	}
 	sk, pk := crypto.GenerateKeyPairDeterministic(entropy)
-	skydEndpoint := os.Getenv("SKYDB_ENDPOINT")
+	skydEndpoint := os.Getenv("CADDY_SKYDB_ENDPOINT")
 	if skydEndpoint == "" {
-		return nil, errors.New("missing SKYDB_ENDPOINT environment variable")
+		return nil, errors.New("missing CADDY_SKYDB_ENDPOINT environment variable")
 	}
 	opts, err := client.DefaultOptions()
 	if err != nil {
@@ -96,17 +96,17 @@ func (db SkyDB) Write(data []byte, dataKey crypto.Hash, rev uint64) error {
 	return nil
 }
 
-// EntropyFromEnv returns the configured value of the SKYDB_ENTROPY environment
+// EntropyFromEnv returns the configured value of the CADDY_SKYDB_ENTROPY environment
 // variable or an error.
 func EntropyFromEnv() (crypto.Hash, error) {
 	var e crypto.Hash
-	eStr := os.Getenv("SKYDB_ENTROPY")
+	eStr := os.Getenv("CADDY_SKYDB_ENTROPY")
 	if eStr == "" {
-		return e, errors.New("missing or empty SKYDB_ENTROPY environment variable. it needs to contain 32 bytes of base64 encoded entropy.")
+		return e, errors.New("missing or empty CADDY_SKYDB_ENTROPY environment variable. it needs to contain 32 bytes of base64 encoded entropy.")
 	}
 	eBytes, err := base64.StdEncoding.DecodeString(eStr)
 	if err != nil || len(eBytes) != 32 {
-		return e, fmt.Errorf("invalid SKYDB_ENTROPY environment variable. it needs to contain 32 bytes of base64 encoded entropy. error: %v", err)
+		return e, fmt.Errorf("invalid CADDY_SKYDB_ENTROPY environment variable. it needs to contain 32 bytes of base64 encoded entropy. error: %v", err)
 	}
 	copy(e[:], eBytes)
 	return e, nil

--- a/skydb/skydb.go
+++ b/skydb/skydb.go
@@ -67,11 +67,9 @@ func (db SkyDB) Read(dataKey crypto.Hash) ([]byte, uint64, error) {
 	s, rev, err := registryRead(db.Client, db.pk, dataKey)
 	// This error string covers both "not found" and "not found in time".
 	if err != nil && (errors.Contains(err, renter.ErrRegistryEntryNotFound) || errors.Contains(err, renter.ErrRegistryLookupTimeout)) {
-		fmt.Println(" >>> Read: Not Found:", err)
 		return nil, 0, ErrNotFound
 	}
 	if err != nil {
-		fmt.Println(" >>> Read: Error:", err)
 		return nil, 0, errors.AddContext(err, "skydb failed to read from registry")
 	}
 	b, err := db.Client.SkynetSkylinkGet(s.String())

--- a/skydb/skydb.go
+++ b/skydb/skydb.go
@@ -66,7 +66,6 @@ func New() (*SkyDB, error) {
 func (db SkyDB) Read(dataKey crypto.Hash) ([]byte, uint64, error) {
 	waitUntilSkydReady(db.Client)
 	s, rev, err := registryRead(db.Client, db.pk, dataKey)
-	// This error string covers both "not found" and "not found in time".
 	if err != nil && (strings.Contains(err.Error(), renter.ErrRegistryEntryNotFound.Error()) || strings.Contains(err.Error(), renter.ErrRegistryLookupTimeout.Error())) {
 		return nil, 0, ErrNotFound
 	}

--- a/skydb/skydb.go
+++ b/skydb/skydb.go
@@ -76,6 +76,9 @@ func (db SkyDB) Read(dataKey crypto.Hash) ([]byte, uint64, error) {
 		return nil, 0, errors.AddContext(err, "skydb failed to read from registry")
 	}
 	b, err := db.Client.SkynetSkylinkGet(s.String())
+	if err != nil && strings.Contains(err.Error(), "workers were unable to recover the data by sector root - all workers failed") {
+		return nil, 0, ErrNotFound
+	}
 	if err != nil {
 		return nil, 0, errors.AddContext(err, "failed to download data from Skynet")
 	}

--- a/skydb/skydb.go
+++ b/skydb/skydb.go
@@ -51,7 +51,7 @@ func New() (*SkyDB, error) {
 	}
 	opts.Address = skydEndpoint
 	skydb := &SkyDB{
-		Client: &client.Client{opts},
+		Client: &client.Client{Options: opts},
 		sk:     sk,
 		pk:     pk,
 	}

--- a/storage.go
+++ b/storage.go
@@ -248,7 +248,6 @@ func (s *Storage) Lock(ctx context.Context, key string) error {
 	for {
 		it, _, err := s.getItem(lockKey)
 		if err != nil && !errors.Contains(err, errNotExist) {
-			fmt.Println("Err: Lock:", err.Error())
 			return err
 		}
 		// if lock doesn't exist or is empty, break to create a new one

--- a/storage.go
+++ b/storage.go
@@ -414,7 +414,10 @@ func errNotFound(err error) bool {
 	fmt.Println(" Details ErrRegistryEntryNotFound:", errors.Contains(err, renter.ErrRegistryEntryNotFound))
 	fmt.Println(" Details ErrRegistryLookupTimeout:", errors.Contains(err, renter.ErrRegistryLookupTimeout))
 
-	return err != nil && (errors.Contains(err, skydb.ErrNotFound) || errors.Contains(err, renter.ErrRegistryEntryNotFound) || errors.Contains(err, renter.ErrRegistryLookupTimeout))
+	result = err!=nil && (strings.Contains(err.Error(), "entry not found"))
+	fmt.Println(" >>> errNotFound (new):", result)
+
+	return result
 }
 
 func isEmpty(data []byte) bool {

--- a/storage.go
+++ b/storage.go
@@ -81,8 +81,8 @@ func (s *Storage) initConfig() error {
 
 // Store puts value at key.
 func (s *Storage) Store(key string, value []byte) error {
-	var err error
-	if err = s.initConfig(); err != nil {
+	err := s.initConfig()
+	if err != nil {
 		return err
 	}
 

--- a/storage.go
+++ b/storage.go
@@ -293,7 +293,6 @@ func (s *Storage) Unlock(key string) error {
 func (s *Storage) getItem(key string) (Item, uint64, error) {
 	dataKey := crypto.HashBytes([]byte(key))
 	data, rev, err := s.SkyDB.Read(dataKey)
-	// The string check is annoying and probably unnecessary but I want to get this working.
 	if errNotFound(err) {
 		return Item{}, 0, errNotExist
 	}

--- a/storage.go
+++ b/storage.go
@@ -245,6 +245,7 @@ func (s *Storage) Lock(ctx context.Context, key string) error {
 	for {
 		it, _, err := s.getItem(lockKey)
 		if err != nil && !errors.Contains(err, errNotExist) {
+			fmt.Println("Err: Lock:", err.Error())
 			return err
 		}
 		// if lock doesn't exist or is empty, break to create a new one
@@ -293,7 +294,8 @@ func (s *Storage) Unlock(key string) error {
 func (s *Storage) getItem(key string) (Item, uint64, error) {
 	dataKey := crypto.HashBytes([]byte(key))
 	data, rev, err := s.SkyDB.Read(dataKey)
-	if err != nil && errors.Contains(err, skydb.ErrNotFound) {
+	// The string check is annoying and probably unnecessary but I want to get this working.
+	if err != nil && (errors.Contains(err, skydb.ErrNotFound) || strings.Contains(err.Error(), "registry entry not found")) {
 		return Item{}, 0, errNotExist
 	}
 	if err != nil {

--- a/storage.go
+++ b/storage.go
@@ -81,7 +81,6 @@ func (s *Storage) initConfig() error {
 
 // Store puts value at key.
 func (s *Storage) Store(key string, value []byte) error {
-	// fmt.Println(" >>> Store ", key)
 	var err error
 	if err = s.initConfig(); err != nil {
 		return err
@@ -126,7 +125,6 @@ func (s *Storage) Store(key string, value []byte) error {
 
 // Load retrieves the value at key.
 func (s *Storage) Load(key string) ([]byte, error) {
-	//fmt.Println(" >>> Load ", key)
 	if err := s.initConfig(); err != nil {
 		return []byte{}, err
 	}
@@ -139,13 +137,11 @@ func (s *Storage) Load(key string) ([]byte, error) {
 	if err != nil {
 		return []byte{}, err
 	}
-	//fmt.Println(" >>> Load ", key, string(domainItem.Contents))
 	return domainItem.Contents, err
 }
 
 // Delete deletes key.
 func (s *Storage) Delete(key string) error {
-	//fmt.Println(" >>> Delete ", key)
 	return s.Store(key, emptyRegistryEntry[:])
 }
 
@@ -165,7 +161,6 @@ func (s *Storage) Exists(key string) bool {
 // should be walked); otherwise, only keys
 // prefixed exactly by prefix will be listed.
 func (s *Storage) List(prefix string, _ bool) ([]string, error) {
-	//fmt.Println(" >>> List ", prefix)
 	if err := s.initConfig(); err != nil {
 		return []string{}, err
 	}
@@ -188,13 +183,11 @@ func (s *Storage) List(prefix string, _ bool) ([]string, error) {
 			matchingKeys = append(matchingKeys, key)
 		}
 	}
-	//fmt.Printf(" >>> List %s, %v\n", prefix, matchingKeys)
 	return matchingKeys, nil
 }
 
 // Stat returns information about key.
 func (s *Storage) Stat(key string) (certmagic.KeyInfo, error) {
-	//fmt.Println(" >>> Stat ", key)
 	domainItem, _, err := s.getItem(key)
 	if err != nil && !errors.Contains(err, errNotExist) {
 		return certmagic.KeyInfo{}, nil
@@ -202,14 +195,12 @@ func (s *Storage) Stat(key string) (certmagic.KeyInfo, error) {
 	if err != nil {
 		return certmagic.KeyInfo{}, err
 	}
-	ki := certmagic.KeyInfo{
+	return certmagic.KeyInfo{
 		Key:        key,
 		Modified:   domainItem.LastUpdated,
 		Size:       int64(len(domainItem.Contents)),
 		IsTerminal: true,
-	}
-	//fmt.Printf(" >>> Stat %s: %+v\n", key, ki)
-	return ki, nil
+	}, nil
 }
 
 // Lock acquires the lock for key, blocking until the lock
@@ -230,7 +221,6 @@ func (s *Storage) Stat(key string) (certmagic.KeyInfo, error) {
 // case Unlock is unable to be called due to some sort of network
 // failure or system crash.
 func (s *Storage) Lock(ctx context.Context, key string) error {
-	//fmt.Println(" >>> Lock ", key)
 	if err := s.initConfig(); err != nil {
 		return err
 	}
@@ -281,8 +271,6 @@ func (s *Storage) Lock(ctx context.Context, key string) error {
 	}
 	dataKey := crypto.HashBytes([]byte(it.PrimaryKey))
 	return s.SkyDB.Write(bytes, dataKey, rev+1)
-
-	//return s.Store(lockKey, contents)
 }
 
 // Unlock releases the lock for key. This method must ONLY be
@@ -290,7 +278,6 @@ func (s *Storage) Lock(ctx context.Context, key string) error {
 // critical section is finished, even if it errored or timed
 // out. Unlock cleans up any resources allocated during Lock.
 func (s *Storage) Unlock(key string) error {
-	//fmt.Println(" >>> Unlock ", key)
 	if err := s.initConfig(); err != nil {
 		return err
 	}
@@ -313,12 +300,10 @@ func (s *Storage) Unlock(key string) error {
 	}
 	dataKey := crypto.HashBytes([]byte(it.PrimaryKey))
 	return s.SkyDB.Write(bytes, dataKey, rev+1)
-	//return s.Delete(lockKey)
 }
 
 // getItem fetches an ItemRecord from SkyDB.
 func (s *Storage) getItem(key string) (Item, uint64, error) {
-	//fmt.Println(" >>> getItem:", key)
 	dataKey := crypto.HashBytes([]byte(key))
 	data, rev, err := s.SkyDB.Read(dataKey)
 	// The string check is annoying and probably unnecessary but I want to get this working.
@@ -337,12 +322,10 @@ func (s *Storage) getItem(key string) (Item, uint64, error) {
 	if err != nil {
 		return Item{}, 0, err
 	}
-	//fmt.Printf(" >>> getItem: %s, %+v, %d\n", key, it, rev)
 	return it, rev, nil
 }
 
 func (s *Storage) keyList() (map[string]bool, uint64, error) {
-	//fmt.Println(" >>> Fetching keylist. DataKey: " + string(s.KeyListDataKey[:]))
 	keyList := make(map[string]bool)
 	klData, rev, err := s.SkyDB.Read(s.KeyListDataKey)
 	if err != nil {
@@ -354,7 +337,6 @@ func (s *Storage) keyList() (map[string]bool, uint64, error) {
 			return nil, 0, errors.AddContext(err, "failed to unmarshal key list")
 		}
 	}
-	//fmt.Printf(">>> Keylist: %+v\n", keyList)
 	return keyList, rev, nil
 }
 

--- a/storage.go
+++ b/storage.go
@@ -12,7 +12,6 @@ import (
 	"github.com/caddyserver/caddy/v2"
 	"github.com/caddyserver/certmagic"
 	"gitlab.com/NebulousLabs/errors"
-	"gitlab.com/SkynetLabs/skyd/skymodules/renter"
 	"go.sia.tech/siad/crypto"
 )
 
@@ -408,16 +407,11 @@ func (s *Storage) keyListDelete(key string) error {
 // errNotFound checks the various failure modes of the registry which all mean
 // that the entry was not found.
 func errNotFound(err error) bool {
-	result := err != nil && (errors.Contains(err, skydb.ErrNotFound) || errors.Contains(err, renter.ErrRegistryEntryNotFound) || errors.Contains(err, renter.ErrRegistryLookupTimeout))
-	fmt.Println(" >>> errNotFound:", err, "will return ", result)
-	fmt.Println(" Details ErrNotFound:", errors.Contains(err, skydb.ErrNotFound))
-	fmt.Println(" Details ErrRegistryEntryNotFound:", errors.Contains(err, renter.ErrRegistryEntryNotFound))
-	fmt.Println(" Details ErrRegistryLookupTimeout:", errors.Contains(err, renter.ErrRegistryLookupTimeout))
-
-	result = err!=nil && (strings.Contains(err.Error(), "entry not found"))
-	fmt.Println(" >>> errNotFound (new):", result)
-
-	return result
+	// This check covers all cases:
+	// - skydb.ErrNotFound
+	// - renter.ErrRegistryEntryNotFound
+	// - renter.ErrRegistryLookupTimeout
+	return err != nil && (strings.Contains(err.Error(), "entry not found"))
 }
 
 func isEmpty(data []byte) bool {

--- a/storage.go
+++ b/storage.go
@@ -110,6 +110,9 @@ func (s *Storage) Store(key string, value []byte) error {
 		if err == nil {
 			break
 		}
+		if triesLeft > 0 {
+			fmt.Println("failed to modify keylist, will try again. error:", err)
+		}
 		time.Sleep(keylistModificationSleep * time.Second)
 	}
 	if err != nil {
@@ -405,6 +408,12 @@ func (s *Storage) keyListDelete(key string) error {
 // errNotFound checks the various failure modes of the registry which all mean
 // that the entry was not found.
 func errNotFound(err error) bool {
+	result := err != nil && (errors.Contains(err, skydb.ErrNotFound) || errors.Contains(err, renter.ErrRegistryEntryNotFound) || errors.Contains(err, renter.ErrRegistryLookupTimeout))
+	fmt.Println(" >>> errNotFound:", err, "will return ", result)
+	fmt.Println(" Details ErrNotFound:", errors.Contains(err, skydb.ErrNotFound))
+	fmt.Println(" Details ErrRegistryEntryNotFound:", errors.Contains(err, renter.ErrRegistryEntryNotFound))
+	fmt.Println(" Details ErrRegistryLookupTimeout:", errors.Contains(err, renter.ErrRegistryLookupTimeout))
+
 	return err != nil && (errors.Contains(err, skydb.ErrNotFound) || errors.Contains(err, renter.ErrRegistryEntryNotFound) || errors.Contains(err, renter.ErrRegistryLookupTimeout))
 }
 

--- a/storage.go
+++ b/storage.go
@@ -400,8 +400,8 @@ func errNotFound(err error) bool {
 		return false
 	}
 	return errors.Contains(err, skydb.ErrNotFound) ||
-		errors.Contains(err, renter.ErrRegistryEntryNotFound) ||
-		errors.Contains(err, renter.ErrRegistryLookupTimeout)
+		strings.Contains(err.Error(), renter.ErrRegistryEntryNotFound.Error()) ||
+		strings.Contains(err.Error(), renter.ErrRegistryLookupTimeout.Error())
 }
 
 func isEmpty(data []byte) bool {

--- a/storage.go
+++ b/storage.go
@@ -81,7 +81,7 @@ func (s *Storage) initConfig() error {
 
 // Store puts value at key.
 func (s *Storage) Store(key string, value []byte) error {
-	fmt.Println(" >>> Store ", key)
+	// fmt.Println(" >>> Store ", key)
 	var err error
 	if err = s.initConfig(); err != nil {
 		return err
@@ -126,7 +126,7 @@ func (s *Storage) Store(key string, value []byte) error {
 
 // Load retrieves the value at key.
 func (s *Storage) Load(key string) ([]byte, error) {
-	fmt.Println(" >>> Load ", key)
+	//fmt.Println(" >>> Load ", key)
 	if err := s.initConfig(); err != nil {
 		return []byte{}, err
 	}
@@ -139,13 +139,13 @@ func (s *Storage) Load(key string) ([]byte, error) {
 	if err != nil {
 		return []byte{}, err
 	}
-	fmt.Println(" >>> Load ", key, string(domainItem.Contents))
+	//fmt.Println(" >>> Load ", key, string(domainItem.Contents))
 	return domainItem.Contents, err
 }
 
 // Delete deletes key.
 func (s *Storage) Delete(key string) error {
-	fmt.Println(" >>> Delete ", key)
+	//fmt.Println(" >>> Delete ", key)
 	return s.Store(key, emptyRegistryEntry[:])
 }
 
@@ -165,7 +165,7 @@ func (s *Storage) Exists(key string) bool {
 // should be walked); otherwise, only keys
 // prefixed exactly by prefix will be listed.
 func (s *Storage) List(prefix string, _ bool) ([]string, error) {
-	fmt.Println(" >>> List ", prefix)
+	//fmt.Println(" >>> List ", prefix)
 	if err := s.initConfig(); err != nil {
 		return []string{}, err
 	}
@@ -188,13 +188,13 @@ func (s *Storage) List(prefix string, _ bool) ([]string, error) {
 			matchingKeys = append(matchingKeys, key)
 		}
 	}
-	fmt.Printf(" >>> List %s, %v\n", prefix, matchingKeys)
+	//fmt.Printf(" >>> List %s, %v\n", prefix, matchingKeys)
 	return matchingKeys, nil
 }
 
 // Stat returns information about key.
 func (s *Storage) Stat(key string) (certmagic.KeyInfo, error) {
-	fmt.Println(" >>> Stat ", key)
+	//fmt.Println(" >>> Stat ", key)
 	domainItem, _, err := s.getItem(key)
 	if err != nil && !errors.Contains(err, errNotExist) {
 		return certmagic.KeyInfo{}, nil
@@ -208,7 +208,7 @@ func (s *Storage) Stat(key string) (certmagic.KeyInfo, error) {
 		Size:       int64(len(domainItem.Contents)),
 		IsTerminal: true,
 	}
-	fmt.Printf(" >>> Stat %s: %+v\n", key, ki)
+	//fmt.Printf(" >>> Stat %s: %+v\n", key, ki)
 	return ki, nil
 }
 
@@ -230,7 +230,7 @@ func (s *Storage) Stat(key string) (certmagic.KeyInfo, error) {
 // case Unlock is unable to be called due to some sort of network
 // failure or system crash.
 func (s *Storage) Lock(ctx context.Context, key string) error {
-	fmt.Println(" >>> Lock ", key)
+	//fmt.Println(" >>> Lock ", key)
 	if err := s.initConfig(); err != nil {
 		return err
 	}
@@ -290,7 +290,7 @@ func (s *Storage) Lock(ctx context.Context, key string) error {
 // critical section is finished, even if it errored or timed
 // out. Unlock cleans up any resources allocated during Lock.
 func (s *Storage) Unlock(key string) error {
-	fmt.Println(" >>> Unlock ", key)
+	//fmt.Println(" >>> Unlock ", key)
 	if err := s.initConfig(); err != nil {
 		return err
 	}
@@ -318,7 +318,7 @@ func (s *Storage) Unlock(key string) error {
 
 // getItem fetches an ItemRecord from SkyDB.
 func (s *Storage) getItem(key string) (Item, uint64, error) {
-	fmt.Println(" >>> getItem:", key)
+	//fmt.Println(" >>> getItem:", key)
 	dataKey := crypto.HashBytes([]byte(key))
 	data, rev, err := s.SkyDB.Read(dataKey)
 	// The string check is annoying and probably unnecessary but I want to get this working.
@@ -337,12 +337,12 @@ func (s *Storage) getItem(key string) (Item, uint64, error) {
 	if err != nil {
 		return Item{}, 0, err
 	}
-	fmt.Printf(" >>> getItem: %s, %+v, %d\n", key, it, rev)
+	//fmt.Printf(" >>> getItem: %s, %+v, %d\n", key, it, rev)
 	return it, rev, nil
 }
 
 func (s *Storage) keyList() (map[string]bool, uint64, error) {
-	fmt.Println(" >>> Fetching keylist. DataKey: " + string(s.KeyListDataKey[:]))
+	//fmt.Println(" >>> Fetching keylist. DataKey: " + string(s.KeyListDataKey[:]))
 	keyList := make(map[string]bool)
 	klData, rev, err := s.SkyDB.Read(s.KeyListDataKey)
 	if err != nil {
@@ -354,7 +354,7 @@ func (s *Storage) keyList() (map[string]bool, uint64, error) {
 			return nil, 0, errors.AddContext(err, "failed to unmarshal key list")
 		}
 	}
-	fmt.Printf(">>> Keylist: %+v\n", keyList)
+	//fmt.Printf(">>> Keylist: %+v\n", keyList)
 	return keyList, rev, nil
 }
 

--- a/storage.go
+++ b/storage.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"gitlab.com/SkynetLabs/skyd/skymodules/renter"
 	"strings"
 	"time"
 
@@ -395,11 +396,12 @@ func (s *Storage) writeItem(pk string, contents []byte, rev uint64) error {
 // errNotFound checks the various failure modes of the registry which all mean
 // that the entry was not found.
 func errNotFound(err error) bool {
-	// This check covers all cases:
-	// - skydb.ErrNotFound
-	// - renter.ErrRegistryEntryNotFound
-	// - renter.ErrRegistryLookupTimeout
-	return err != nil && (strings.Contains(err.Error(), "entry not found"))
+	if err == nil {
+		return false
+	}
+	return errors.Contains(err, skydb.ErrNotFound) ||
+		errors.Contains(err, renter.ErrRegistryEntryNotFound) ||
+		errors.Contains(err, renter.ErrRegistryLookupTimeout)
 }
 
 func isEmpty(data []byte) bool {

--- a/storage.go
+++ b/storage.go
@@ -73,6 +73,9 @@ func (s *Storage) initConfig() error {
 	if s.LockPollingInterval == 0 {
 		s.LockPollingInterval = lockPollingInterval
 	}
+	if isEmpty(s.KeyListDataKey[:]) {
+		s.KeyListDataKey = crypto.HashBytes([]byte("key_list"))
+	}
 	return nil
 }
 
@@ -327,6 +330,7 @@ func (s *Storage) keyList() (map[string]bool, uint64, error) {
 	}
 	return keyList, rev, nil
 }
+
 func isEmpty(data []byte) bool {
 	for _, v := range data {
 		if v > 0 {


### PR DESCRIPTION
When we start the portal stack we typically wait for the `sia` container to start before we start the `caddy` one. The issue is that even though the `sia` container has started, it might take several **minutes** before it's ready to accept API calls. During that time all registry calls to the node will result in `490 Module not loaded` error. Caddy will keep restarting and retrying for a while (10 times) but that might be insufficient.

This PR adds a built-in retry mechanism with a progressive backoff that will hopefully allow us to wait for `skyd` to be fully ready to accept connections.