### PR TITLE
Switch from base64 to hex

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # envVars defines all the environment variables the project depends on. These
 # are typically provided by docker-compose files or .env files.
 envVars= \
-	CADDY_SKYDB_ENTROPY=lJAuxnufpy7BbNCbVUKWShIinDBipdnd1hr/d/ZqHLI= \
+	CADDY_SKYDB_ENTROPY=94902ec67b9fa72ec16cd09b5542964a12229c3062a5d9ddd61aff77f66a1cb2 \
 	CADDY_SKYDB_ENDPOINT=localhost:9980
 
 deps:

--- a/caddy.go
+++ b/caddy.go
@@ -1,7 +1,7 @@
 package skydbstorage
 
 import (
-	"encoding/base64"
+	"encoding/hex"
 	"github.com/caddyserver/caddy/v2"
 	"github.com/caddyserver/caddy/v2/caddyconfig/caddyfile"
 	"github.com/caddyserver/certmagic"
@@ -35,7 +35,7 @@ func (s *Storage) CertMagicStorage() (certmagic.Storage, error) {
 // UnmarshalCaddyfile sets up the storage module from Caddyfile tokens. Syntax:
 //
 // skydb {
-// 		key_list_datakey <base64 encoded dataKey>
+// 		key_list_datakey <hex encoded dataKey>
 // }
 //
 // Optional. If not provided, the hardcoded key will be used.
@@ -50,7 +50,7 @@ func (s *Storage) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
 				if !d.NextArg() {
 					return d.ArgErr()
 				}
-				dk, err := base64.StdEncoding.DecodeString(d.Val())
+				dk, err := hex.DecodeString(d.Val())
 				if err != nil {
 					return d.Errf("failed to decode key list dataKey. Error: %v", err)
 				}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,6 @@ services:
     command: make
     environment:
       CADDY_SKYDB_ENDPOINT: localhost:9980
-      CADDY_SKYDB_ENTROPY: ZnXVDQI5SIf3B+bBHM6GJe8nuV9yZm9HSO7liWeo6yk=
+      CADDY_SKYDB_ENTROPY: 6675d50d02394887f707e6c11cce8625ef27b95f72666f4748eee58967a8eb29
     volumes:
       - ./:/certmagic-storage-skydb

--- a/skydb/skydb.go
+++ b/skydb/skydb.go
@@ -2,7 +2,7 @@ package skydb
 
 import (
 	"bytes"
-	"encoding/base64"
+	"encoding/hex"
 	"fmt"
 	"os"
 	"strings"
@@ -108,17 +108,17 @@ func (db SkyDB) Write(data []byte, dataKey crypto.Hash, rev uint64) error {
 	return nil
 }
 
-// EntropyFromEnv returns the configured value of the CADDY_SKYDB_ENTROPY environment
-// variable or an error.
+// EntropyFromEnv returns the configured value of the CADDY_SKYDB_ENTROPY
+// environment variable or an error.
 func EntropyFromEnv() (crypto.Hash, error) {
 	var e crypto.Hash
 	eStr := os.Getenv("CADDY_SKYDB_ENTROPY")
 	if eStr == "" {
-		return e, errors.New("missing or empty CADDY_SKYDB_ENTROPY environment variable. it needs to contain 32 bytes of base64 encoded entropy.")
+		return e, errors.New("missing or empty CADDY_SKYDB_ENTROPY environment variable. it needs to contain 32 bytes of hex-encoded entropy.")
 	}
-	eBytes, err := base64.StdEncoding.DecodeString(eStr)
-	if err != nil || len(eBytes) != 32 {
-		return e, fmt.Errorf("invalid CADDY_SKYDB_ENTROPY environment variable. it needs to contain 32 bytes of base64 encoded entropy. error: %v", err)
+	eBytes, err := hex.DecodeString(eStr)
+	if err != nil {
+		return e, err
 	}
 	copy(e[:], eBytes)
 	return e, nil


### PR DESCRIPTION
Also remove the requirement that the entropy provided in the config file contains exactly 32 bytes. Now it can contain as much as it wants, as long as it's not empty.